### PR TITLE
Port to Python 3.

### DIFF
--- a/command_runner
+++ b/command_runner
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 """A panel applet which periodically runs a command and displays its output."""
 
@@ -49,9 +49,9 @@ def logged(f):
 	def wrapped(*args, **kwargs):
 		try:
 			return f(*args, **kwargs)
-		except Exception, e:
+		except Exception as e:
 			logging.exception(e)
-			raise e
+			raise
 	wrapped.__doc__ = f.__doc__
 	return wrapped
 
@@ -186,10 +186,10 @@ class CommandRunner(object):
 			t = subprocess.Popen(self.command, stdout=subprocess.PIPE, shell=True).communicate()[0].rstrip()
 			# TODO: the output could be large, it needs to be trimmed to a sensible size
 			logging.debug('Got [%s] from command', t)
-			self.label.set_text(t)
-		except Exception, e:
+			self.label.set_text(t.decode('utf-8', 'replace'))
+		except Exception as e:
 			logging.exception(e)
-			raise e
+			raise
 		finally:
 			GObject.timeout_add(5000, self.run_command)
 
@@ -204,7 +204,7 @@ def command_applet_factory(applet, iid, data):
 		logging.info('Applet created successfully. Showing it now.')
 		runner.run()
 		return True
-	except Exception, e:
+	except Exception as e:
 		logging.info('Failed to create or run applet.')
 		logging.exception(e)
 		os._exit(1)


### PR DESCRIPTION
- Use `except Foo as bar` instead of `except Foo, bar` (this is also
  compatible with Python 2).
- Decode command output as UTF-8.
- Update shebang.

The needed change in debian/control will be just:

``` diff
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/porridge/command-runner-applet

 Package: command-runner-applet
 Architecture: all
-Depends: ${misc:Depends}, python, python-gi,
+Depends: ${misc:Depends}, python3, python3-gi,
  gir1.2-gtk-3.0, gir1.2-gdkpixbuf-2.0,
  gir1.2-panelapplet-5.0
 Description: panel applet which periodically displays a command output
```
